### PR TITLE
Add question navigation with cookie persistence

### DIFF
--- a/src/main/java/com/li/javainterview/controller/QuestionController.java
+++ b/src/main/java/com/li/javainterview/controller/QuestionController.java
@@ -2,11 +2,17 @@ package com.li.javainterview.controller;
 
 import com.li.javainterview.service.QuestionService;
 import com.li.javainterview.model.QuestionAnswer;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpSession;
 import org.springframework.stereotype.Controller;
 import org.springframework.ui.Model;
+import org.springframework.web.bind.annotation.CookieValue;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 
+import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.List;
 import java.util.Optional;
 
@@ -20,16 +26,84 @@ public class QuestionController {
     }
 
     @GetMapping("/")
-    public String categories(Model model) {
+    public String categories(Model model,
+                             @CookieValue(value = "categories", required = false) String categoriesCookie,
+                             HttpSession session) {
         model.addAttribute("categories", service.categories());
+        if (categoriesCookie != null) {
+            List<String> selected = parseCategories(categoriesCookie);
+            model.addAttribute("selectedCategories", selected);
+            session.setAttribute("categories", selected);
+        }
+        session.removeAttribute("history");
+        session.removeAttribute("index");
         return "index";
     }
 
     @GetMapping("/question")
-    public String randomQuestion(@RequestParam(name = "category") List<String> categories, Model model) {
-        Optional<QuestionAnswer> qa = service.getRandomQuestion(categories);
-        qa.ifPresent(q -> model.addAttribute("qa", q));
+    public String randomQuestion(@RequestParam(name = "category", required = false) List<String> categories,
+                                 @RequestParam(name = "nav", required = false) String nav,
+                                 @CookieValue(value = "categories", required = false) String categoriesCookie,
+                                 HttpServletResponse response,
+                                 HttpSession session,
+                                 Model model) {
+        if (categories != null) {
+            Cookie c = new Cookie("categories", String.join(",", categories));
+            c.setPath("/");
+            c.setMaxAge(60 * 60 * 24 * 30);
+            response.addCookie(c);
+            session.setAttribute("categories", categories);
+            session.removeAttribute("history");
+            session.removeAttribute("index");
+        } else {
+            Object fromSession = session.getAttribute("categories");
+            if (fromSession == null && categoriesCookie != null) {
+                categories = parseCategories(categoriesCookie);
+                session.setAttribute("categories", categories);
+            } else {
+                categories = (List<String>) fromSession;
+            }
+        }
+
+        List<QuestionAnswer> history = (List<QuestionAnswer>) session.getAttribute("history");
+        Integer index = (Integer) session.getAttribute("index");
+        if (history == null) {
+            history = new ArrayList<>();
+            index = -1;
+        }
+
+        QuestionAnswer qa = null;
+        if ("back".equals(nav)) {
+            if (index != null && index > 0) {
+                index--;
+                qa = history.get(index);
+            }
+        } else {
+            if (index != null && history.size() > index + 1) {
+                history = history.subList(0, index + 1);
+            }
+            Optional<QuestionAnswer> opt = service.getRandomQuestion(categories);
+            if (opt.isPresent()) {
+                qa = opt.get();
+                history.add(qa);
+                index = index == null ? 0 : index + 1;
+            }
+        }
+
+        session.setAttribute("history", history);
+        session.setAttribute("index", index);
+
+        if (qa != null) {
+            model.addAttribute("qa", qa);
+        }
         model.addAttribute("categories", categories);
         return "question";
+    }
+
+    private List<String> parseCategories(String value) {
+        return Arrays.stream(value.split(","))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .toList();
     }
 }

--- a/src/main/java/com/li/javainterview/model/QuestionAnswer.java
+++ b/src/main/java/com/li/javainterview/model/QuestionAnswer.java
@@ -6,6 +6,7 @@ import lombok.Data;
 @Data
 @AllArgsConstructor
 public class QuestionAnswer {
+    private String category;
     private String question;
     private String answer;
 }

--- a/src/main/java/com/li/javainterview/service/QuestionService.java
+++ b/src/main/java/com/li/javainterview/service/QuestionService.java
@@ -77,7 +77,7 @@ public class QuestionService {
                                 String link = m.group(2);
                                 String fileName = link.split("#", 2)[0];
                                 String answer = parseQuestionFile(fileName, question);
-                                list.add(new QuestionAnswer(question, answer));
+                                list.add(new QuestionAnswer(category, question, answer));
                             }
                         } else if (qLine.startsWith("## ") || qLine.startsWith("[к оглавлению") || qLine.isEmpty()) {
                             break;

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -10,7 +10,7 @@
     <ul>
         <li th:each="cat : ${categories}">
             <label>
-                <input type="checkbox" name="category" th:value="${cat}"/>
+                <input type="checkbox" name="category" th:value="${cat}" th:checked="${selectedCategories != null} ? ${selectedCategories.contains(cat)} : false"/>
                 <span th:text="${cat}"></span>
             </label>
         </li>

--- a/src/main/resources/templates/question.html
+++ b/src/main/resources/templates/question.html
@@ -7,6 +7,7 @@
 <body>
 <h1 th:text="'Категории: ' + ${#strings.listJoin(categories, ', ')}"></h1>
 <div th:if="${qa != null}">
+    <h2 th:text="${qa.category}"></h2>
     <p th:text="${qa.question}"></p>
     <details>
         <summary>Answer</summary>
@@ -16,6 +17,8 @@
 <div th:if="${qa == null}">
     <p>No questions found.</p>
 </div>
-<a href="/">Back</a>
+<a th:href="@{/}">К категориям</a>
+<a th:href="@{/question(nav='back')}">Назад</a>
+<a th:href="@{/question(nav='next')}">Следующий</a>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- remember selected categories using cookies
- show question category and add navigation
- track question history in session

## Testing
- `mvn -q -DskipTests package` *(fails: Non-resolvable parent POM)*
- `mvn -q test` *(fails: Non-resolvable parent POM)*

------
https://chatgpt.com/codex/tasks/task_e_68598117b60083319d60f82822aae76f