### PR TITLE
Render markdown as HTML

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,11 @@
             <artifactId>spring-boot-starter-web</artifactId>
         </dependency>
         <dependency>
+            <groupId>org.commonmark</groupId>
+            <artifactId>commonmark</artifactId>
+            <version>0.25.0</version>
+        </dependency>
+        <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
             <version>1.18.32</version>

--- a/src/main/java/com/li/javainterview/service/MarkdownService.java
+++ b/src/main/java/com/li/javainterview/service/MarkdownService.java
@@ -1,0 +1,18 @@
+package com.li.javainterview.service;
+
+import org.commonmark.parser.Parser;
+import org.commonmark.renderer.html.HtmlRenderer;
+import org.springframework.stereotype.Service;
+
+@Service
+public class MarkdownService {
+    private final Parser parser = Parser.builder().build();
+    private final HtmlRenderer renderer = HtmlRenderer.builder().build();
+
+    public String toHtml(String markdown) {
+        if (markdown == null || markdown.isEmpty()) {
+            return "";
+        }
+        return renderer.render(parser.parse(markdown));
+    }
+}

--- a/src/main/java/com/li/javainterview/service/QuestionService.java
+++ b/src/main/java/com/li/javainterview/service/QuestionService.java
@@ -6,6 +6,7 @@ import org.springframework.core.io.Resource;
 import org.springframework.core.io.ResourceLoader;
 import org.springframework.stereotype.Service;
 
+
 import java.io.BufferedReader;
 import java.io.IOException;
 import java.io.InputStreamReader;
@@ -19,9 +20,11 @@ public class QuestionService {
     private final Map<String, List<QuestionAnswer>> questionsByCategory = new LinkedHashMap<>();
     private final Random random = new Random();
     private final ResourceLoader resourceLoader;
+    private final MarkdownService markdownService;
 
-    public QuestionService(ResourceLoader resourceLoader) {
+    public QuestionService(ResourceLoader resourceLoader, MarkdownService markdownService) {
         this.resourceLoader = resourceLoader;
+        this.markdownService = markdownService;
     }
 
     private static final Pattern LINK_PATTERN = Pattern.compile("\\+ \\[(.+?)\\]\\((.+?)\\)");
@@ -73,10 +76,12 @@ public class QuestionService {
                         if (qLine.startsWith("+ [")) {
                             Matcher m = LINK_PATTERN.matcher(qLine);
                             if (m.find()) {
-                                String question = m.group(1);
+                                String questionRaw = m.group(1);
                                 String link = m.group(2);
                                 String fileName = link.split("#", 2)[0];
-                                String answer = parseQuestionFile(fileName, question);
+                                String answerMd = parseQuestionFile(fileName, questionRaw);
+                                String question = markdownService.toHtml(questionRaw);
+                                String answer = markdownService.toHtml(answerMd);
                                 list.add(new QuestionAnswer(category, question, answer));
                             }
                         } else if (qLine.startsWith("## ") || qLine.startsWith("[к оглавлению") || qLine.isEmpty()) {

--- a/src/main/resources/templates/question.html
+++ b/src/main/resources/templates/question.html
@@ -12,10 +12,10 @@
 <h1 th:text="'Категории: ' + ${#strings.listJoin(categories, ', ')}"></h1>
 <div th:if="${qa != null}">
     <h2 th:text="${qa.category}"></h2>
-    <p th:text="${qa.question}"></p>
+    <p th:utext="${qa.question}"></p>
     <details>
         <summary>Ответ</summary>
-        <p th:text="${qa.answer}"></p>
+        <p th:utext="${qa.answer}"></p>
     </details>
 </div>
 <div th:if="${qa == null}">


### PR DESCRIPTION
## Summary
- add CommonMark dependency
- add `MarkdownService` to convert markdown to HTML
- convert question and answer text when parsing
- render converted HTML using `th:utext`

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685988cacc64833190ba52b2e0e52b49