### PR TITLE
Apply Syntax layout

### DIFF
--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -1,14 +1,20 @@
-/* Dark theme styles (2024-2025) */
+/* Base layout inspired by syntax.tailwindui.com */
 body {
-    background: linear-gradient(135deg, #0d0d0d, #1a1a1a);
-    color: #f0f0f0;
-    font-family: Arial, Helvetica, sans-serif;
+    background: #ffffff;
+    color: #0f172a;
+    font-family: system-ui, -apple-system, "Segoe UI", Roboto, Helvetica,
+        Arial, sans-serif;
     display: flex;
     flex-direction: column;
-    align-items: center;
-    text-align: center;
     min-height: 100vh;
     margin: 0;
+}
+
+@media (prefers-color-scheme: dark) {
+    body {
+        background: #0f172a;
+        color: #f1f5f9;
+    }
 }
 h1, h2, p {
     margin: 0.5em 0;
@@ -22,6 +28,13 @@ summary {
 details.open > * { animation: fadeIn 0.5s ease forwards; }
 details[open] summary::after {
     animation: fadeIn 0.5s ease forwards;
+}
+main {
+    width: 100%;
+    max-width: 42rem;
+    margin: 0 auto;
+    padding: 1rem;
+    text-align: left;
 }
 @keyframes fadeIn {
     from { opacity: 0; }

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html xmlns:th="http://www.thymeleaf.org" data-theme="synthwave">
+<html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>Interview Questions</title>
     <meta charset="UTF-8"/>
@@ -8,7 +8,8 @@
     <link rel="stylesheet" th:href="@{/style.css}"/>
     <script th:src="@{/script.js}" defer></script>
 </head>
-<body class="min-h-screen flex flex-col items-center text-center p-4">
+<body class="flex min-h-full flex-col bg-white dark:bg-slate-900">
+<main class="mx-auto w-full max-w-2xl px-4 sm:px-6 lg:px-8">
 <h1>Выберите категории</h1>
 <form action="/question" method="get">
     <ul>
@@ -21,5 +22,6 @@
     </ul>
     <button type="submit" class="btn btn-primary mt-2">Получить вопросы</button>
 </form>
+</main>
 </body>
 </html>

--- a/src/main/resources/templates/question.html
+++ b/src/main/resources/templates/question.html
@@ -1,5 +1,5 @@
 <!DOCTYPE HTML>
-<html xmlns:th="http://www.thymeleaf.org" data-theme="synthwave">
+<html xmlns:th="http://www.thymeleaf.org">
 <head>
     <title>Вопрос</title>
     <meta charset="UTF-8"/>
@@ -8,7 +8,8 @@
     <link rel="stylesheet" th:href="@{/style.css}"/>
     <script th:src="@{/script.js}" defer></script>
 </head>
-<body class="min-h-screen flex flex-col items-center text-center p-4">
+<body class="flex min-h-full flex-col bg-white dark:bg-slate-900">
+<main class="mx-auto w-full max-w-2xl px-4 sm:px-6 lg:px-8">
 <h1 th:text="'Категории: ' + ${#strings.listJoin(categories, ', ')}"></h1>
 <div th:if="${qa != null}">
     <h2 th:text="${qa.category}"></h2>
@@ -24,5 +25,6 @@
 <a th:href="@{/}" class="btn btn-primary m-1">К категориям</a>
 <a th:href="@{/question(nav='back')}" class="btn m-1">Назад</a>
 <a th:href="@{/question(nav='next')}" class="btn m-1">Следующий</a>
+</main>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- adapt global styles and container width inspired by syntax.tailwindui.com
- switch pages to light/dark background classes and centered container

## Testing
- `mvn test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_685988a708348331acbbb5e3a9f0d660