### PR TITLE
Adjust layout and font sizes

### DIFF
--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -36,7 +36,7 @@ h2 {
 }
 
 ul { list-style: none; padding: 0; }
-ul li { margin-bottom: 0.75em; }
+ul li { margin-bottom: 0.25em; }
 summary {
     cursor: pointer;
     font-weight: bold;
@@ -54,7 +54,7 @@ main {
 }
 
 .markdown-body {
-    font-size: 1.5em; /* larger markdown text */
+    font-size: 2.25em; /* larger markdown text */
 }
 @keyframes fadeIn {
     from { opacity: 0; }
@@ -70,7 +70,7 @@ main {
 }
 
 .question {
-    margin-bottom: 1.5rem; /* increased spacing */
+    margin: 2rem 0; /* more space around question */
 }
 
 details.answer-container {
@@ -79,11 +79,11 @@ details.answer-container {
 
 details.answer-container summary {
     background-color: #1f2937; /* dark style */
-    padding: 0.75rem 1.25rem; /* increased padding */
+    padding: 0.375rem 0.625rem; /* reduced padding */
     border-radius: 0.375rem;
     border: 1px solid #0f172a;
     color: #f8fafc;
-    font-size: 1.65em; /* 50% larger */
+    font-size: 1.1em; /* smaller button */
     font-weight: 600;
     transition: background-color 0.3s, color 0.3s;
     position: relative;
@@ -110,6 +110,7 @@ details.answer-container .answer {
     overflow: hidden;
     opacity: 0;
     transition: max-height 0.5s ease, opacity 0.5s ease;
+    margin: 2rem 0; /* more space around answer */
 }
 
 details.answer-container.open .answer {


### PR DESCRIPTION
## Summary
- tweak margins on the categories list
- increase question/answer text size
- add space around question and answer text
- shrink the "Ответ" button

## Testing
- `mvn -q test` *(fails: `mvn` not found)*

------
https://chatgpt.com/codex/tasks/task_e_685993441f0c83318e2a4b4278e45458