### PR TITLE
Adjust category list size and spacing

### DIFF
--- a/src/main/resources/static/style.css
+++ b/src/main/resources/static/style.css
@@ -37,6 +37,16 @@ h2 {
 
 ul { list-style: none; padding: 0; }
 ul li { margin-bottom: 0.25em; }
+.categories-list {
+    font-size: 75%; /* 25% smaller text */
+    display: grid;
+    grid-template-columns: repeat(2, 1fr); /* two columns */
+    gap: 0.25rem 1rem;
+}
+.categories-list li {
+    padding-top: 0.25rem; /* 50% less vertical padding */
+    padding-bottom: 0.25rem;
+}
 summary {
     cursor: pointer;
     font-weight: bold;

--- a/src/main/resources/templates/index.html
+++ b/src/main/resources/templates/index.html
@@ -12,7 +12,7 @@
 <main class="mx-auto w-full max-w-2xl px-4 sm:px-6 lg:px-8">
 <h1>Выберите категории</h1>
 <form action="/question" method="get">
-    <ul>
+    <ul class="categories-list">
         <li th:each="cat : ${categories}">
             <label>
                 <input type="checkbox" name="category" th:value="${cat}" th:checked="${selectedCategories != null} ? ${selectedCategories.contains(cat)} : false"/>


### PR DESCRIPTION
## Summary
- shrink category list text and padding
- make the list display in two columns

## Testing
- `mvn -q test` *(fails: Could not transfer artifact)*

------
https://chatgpt.com/codex/tasks/task_e_6859aaf65b58833194266b5ef92b2dca